### PR TITLE
Update API base resolution and helper usage

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,7 @@ import {
   ModalOverlay, ModalContent, ModalHeader, ModalCloseButton, ModalBody,
   ModalFooter, Button, SimpleGrid, HStack, Badge, ButtonGroup
 } from "@chakra-ui/react";
-import { API_BASE } from "./config/api"; // HELPER
+import { buildApiUrl } from "./config/api"; // HELPER
 
 import { Munro } from "./types/munro";
 import StatsPanel from "./components/dashboard/StatsPanel";
@@ -47,7 +47,7 @@ export default function App() {
     if (grade) params.append("grade", grade);
     if (bog) params.append("bog", bog);
     axios
-      .get(`${API_BASE}/api/munros?${params.toString()}`)
+      .get(buildApiUrl(`/api/munros?${params.toString()}`))
       .then((res) => {
         let data = res.data as Munro[];
         if (sortKey) {
@@ -80,13 +80,13 @@ export default function App() {
 
   const openRoute = async (route: ChatRouteLink) => {
     try {
-      const res = await axios.get(`${API_BASE}/api/munro/${route.id}`);
+      const res = await axios.get(buildApiUrl(`/api/munro/${route.id}`));
       const munro = res.data as Munro;
       setSelectedMunro(munro);
       setActiveTab("details");
     } catch {
       try {
-        const res2 = await axios.get(`${API_BASE}/api/munros?id=${route.id}`);
+        const res2 = await axios.get(buildApiUrl(`/api/munros?id=${route.id}`));
         const munro = (res2.data as Munro[])[0];
         if (munro) {
           setSelectedMunro(munro);

--- a/client/src/config/api.ts
+++ b/client/src/config/api.ts
@@ -1,12 +1,48 @@
 // client/src/config/api.ts
 
+declare global {
+  interface Window {
+    __MUNRO_API_BASE__?: string;
+  }
+}
+
+const globalWindow: (Window & { __MUNRO_API_BASE__?: string }) | undefined =
+  typeof window === "undefined" ? undefined : window;
+
+const runtimeBase =
+  typeof globalWindow?.__MUNRO_API_BASE__ === "string"
+    ? globalWindow.__MUNRO_API_BASE__
+    : "";
+
 const envBase =
   (typeof process !== "undefined" &&
     (process as unknown as { env?: Record<string, string | undefined> })?.env
       ?.REACT_APP_API_BASE) ||
   "";
 
-export const API_BASE = envBase.trim() || "http://localhost:5000";
+const isDevelopment =
+  typeof process !== "undefined" &&
+  (process as unknown as { env?: Record<string, string | undefined> })?.env
+    ?.NODE_ENV === "development";
+
+const fallbackBase = isDevelopment
+  ? "http://localhost:5000"
+  : typeof globalWindow?.location?.origin === "string"
+  ? globalWindow.location.origin
+  : "";
+
+const resolvedBase = [runtimeBase, envBase, fallbackBase]
+  .map((value) => value.trim())
+  .find((value) => value.length > 0);
+
+export const API_BASE = resolvedBase ?? "";
+
+if (!API_BASE) {
+  // Surface misconfiguration early so API calls don't silently hit the wrong host.
+  console.warn(
+    "Munro Scout: no API base configured; API requests will be sent to relative URLs."
+  );
+}
 
 /**
  * Helper to join the API base with a relative path without duplicating slashes.
@@ -14,5 +50,8 @@ export const API_BASE = envBase.trim() || "http://localhost:5000";
 export function buildApiUrl(path: string): string {
   const normalizedBase = API_BASE.replace(/\/+$/, "");
   const normalizedPath = path.replace(/^\/+/, "");
+  if (!normalizedBase) {
+    return `/${normalizedPath}`;
+  }
   return `${normalizedBase}/${normalizedPath}`;
 }

--- a/client/src/features/chat/ChatTab.tsx
+++ b/client/src/features/chat/ChatTab.tsx
@@ -21,7 +21,7 @@ import {
   Icon,
 } from "@chakra-ui/react";
 import { InfoOutlineIcon, QuestionOutlineIcon, RepeatIcon } from "@chakra-ui/icons";
-import { API_BASE } from "../../config/api"; // HELPER
+import { buildApiUrl } from "../../config/api"; // HELPER
 
 export type ChatRouteLink = { id: number; name: string; tags?: string[] };
 export type ChatMessage = {
@@ -72,7 +72,7 @@ export default function ChatTab({ messages, onSend, onOpenRoute, onReset }: Prop
     try {
       onSend(text); // optimistic append by parent
 
-      const res = await fetch(`${API_BASE}/api/chat`, {
+      const res = await fetch(buildApiUrl("/api/chat"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: text, limit: 8 }),

--- a/client/src/features/details/DetailsTab.tsx
+++ b/client/src/features/details/DetailsTab.tsx
@@ -13,7 +13,7 @@ import { useSelectedGpxUrl } from "../../hooks/useSelectedGpxUrl";
 import { DEFAULT_CENTER } from "../../config/constants";
 import MapRefStash from "../../components/map/MapRefStash";
 import GpxOverlay from "../../components/map/GpxOverlay";
-import { API_BASE } from "../../config/api";
+import { buildApiUrl } from "../../config/api";
 
 type Props = { initialMunro: Munro | null };
 
@@ -41,7 +41,7 @@ export default function DetailsTab({ initialMunro }: Props) {
       try {
         const name = "Ben Nevis";
         const { data } = await axios.get<Munro[]>(
-          `${API_BASE}/api/munros?search=${encodeURIComponent(name)}`
+          buildApiUrl(`/api/munros?search=${encodeURIComponent(name)}`)
         );
         const exact = (data || []).find(
           (m) => m.name?.toLowerCase().trim() === name.toLowerCase()
@@ -68,7 +68,7 @@ export default function DetailsTab({ initialMunro }: Props) {
       return;
     }
     axios
-      .get(`${API_BASE}/api/munros?search=${encodeURIComponent(query)}`)
+      .get(buildApiUrl(`/api/munros?search=${encodeURIComponent(query)}`))
       .then((res) => {
         const list = res.data as Munro[];
         const filtered = list.filter((m) =>


### PR DESCRIPTION
## Summary
- resolve the API base URL at runtime using a window override, environment variable, or location origin with dev-specific fallback
- emit a warning when no API base is configured so API calls rely on relative URLs
- switch client components to use buildApiUrl so they share the updated base resolution logic

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68cc399a1b2483228128da7d9e74ea60