### PR TITLE
Add live site reference and usage guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
-# munro-scout
+# Munro Scout
+
+**Live site:** https://munroapp.onrender.com/
+
+Munro Scout is a full-stack exploration tool for Scotland's Munros. A Vite-powered React client partners with a Flask API to surface curated hill data, coordinate lookups, and LLM-assisted chat guidance for planning ascents.
+
+## How to use
+
+1. Visit the live site to browse Scotland's Munros with searchable listings and rich detail panels.
+2. Apply filters or free-text queries to narrow results by height, region, or descriptive tags.
+3. Open the chat assistant to get personalised suggestions, itinerary tips, and tag clarifications.
+4. Drill into individual Munro pages for coordinates, summaries, and related peaks to plan your day on the hill.
+
+## Repository layout
+
+```
+munro-scout/
+├── client/           # React front-end (TypeScript + Vite)
+├── server/           # Flask API, data services, and background scripts
+├── requirements.txt  # Python dependencies for the API and tooling
+├── package.json      # Root Node dependencies (linting, shared tooling)
+└── README.md
+```
+
+### API service (`server/`)
+
+- `app.py` bootstraps the Flask application, configures CORS, and registers feature blueprints.
+- `routes/` exposes REST endpoints for health checks, Munro listings, free-text search, tag summaries, and the LLM chat surface.
+- `services/` encapsulate search orchestration, geo lookups, and enrichment logic shared across routes.
+- `utils/` normalise user input, parse numeric filters, and compose SQL fragments for ranking.
+- `extensions/llm.py` lazily initialises the configured LLM provider for tagging and chat.
+- `munro_coords.py`, `seed.py`, and `tag_munros.py` build and maintain the SQLite dataset and coordinate cache.
+
+### Client (`client/`)
+
+- Vite + React front end written in TypeScript.
+- Consumes the Flask API for search results, detail panels, and conversational assistance.
+- Leans on component-level state and hooks to orchestrate filters and API requests.
+
+## Stack highlights
+
+| Layer        | Technologies |
+|--------------|--------------|
+| Front end    | React, TypeScript, Vite, CSS Modules |
+| API          | Flask, SQLite, SQLAlchemy-style query helpers |
+| Intelligence | OpenAI-powered chat + tagging workflows |
+| Tooling      | Python virtualenv, npm scripts, dataset maintenance CLIs |
+
+## Techniques in play
+
+- **Structured search parsing** to normalise free-text, range filters, and tag selectors into SQL-ready conditions.
+- **Hybrid ranking** that blends text relevance, numeric heuristics, and optional distance calculations for nearby hill discovery.
+- **LLM-assisted workflows** for both user-facing chat recommendations and back-office tag generation.
+- **Data curation scripts** to geocode missing coordinates, standardise names, and keep the SQLite database in sync.
+- **Blueprint-driven Flask architecture** isolating HTTP concerns from domain services.
+- **Client-side filter orchestration** with React hooks managing query state and optimistic UI feedback.
+
+## Data & automation flow
+
+1. **Seed scripts** ingest CSV datasets, clean descriptions, and populate the SQLite store.
+2. **Coordinate builders** call external geocoding services and cache lat/long pairs for each Munro.
+3. **Tag generation** leverages LLM prompts to classify routes, with review loops to keep taxonomy consistent.
+4. **Search endpoints** stitch the curated data, filters, and scoring strategy together for responsive results.
+
+## Potential features
+
+- Offline-first caching so hill details remain available when signal drops on the hill.
+- Progressive Web App shell for quick-add of favourite Munros and itinerary planning.
+- User accounts to track completed peaks, wishlists, and shared trip reports.
+- Weather and avalanche condition overlays sourced from third-party APIs.
+- Live map visualisations with clustering and gradient difficulty layers.
+
+## Development notes
+
+- Run `python server/munro_coords.py --build` to refresh coordinate caches before recalculating distances.
+- Regenerate descriptive tags with `python server/tag_munros.py --build` once the LLM credentials are set.
+- Adjust default model identifiers via environment variables such as `MUNRO_CHAT_MODEL` to experiment with providers.
+
+Happy exploring!

--- a/server/app.py
+++ b/server/app.py
@@ -7,15 +7,17 @@ import os
 
 
 def create_app() -> Flask:
+    """Create and configure the Flask application instance."""
     load_dotenv()
     app = Flask(__name__)
     app.config.from_object(Config)
     app.config["JSON_AS_ASCII"] = False
     CORS(app)
 
+    # Register all API blueprints and shared teardown handlers.
     register_blueprints(app)
 
-    # just print here
+    # Emit a startup log for container platforms without process logs.
     print("🚀 Starting Munro Flask API...")
 
     return app

--- a/server/check_db.py
+++ b/server/check_db.py
@@ -6,6 +6,7 @@ DB_PATH = "db.sqlite"
 
 
 def preview(table: str = "munros", n: int = 5):
+    """Print the first *n* rows of the requested table for quick inspection."""
     conn = sqlite3.connect(DB_PATH)
     query = f"SELECT * FROM {table} LIMIT {n};"
     df = pd.read_sql_query(query, conn)

--- a/server/db.py
+++ b/server/db.py
@@ -3,20 +3,25 @@ from flask import current_app, g
 
 
 def get_db():
+    """Return a cached SQLite connection for the current Flask request."""
     if "db_conn" not in g:
         path = current_app.config["DB_PATH"]
         conn = sqlite3.connect(path)
         conn.row_factory = sqlite3.Row
+        # Store the connection on the Flask request context for reuse.
         g.db_conn = conn
     return g.db_conn
 
 
 def close_db(e=None):
+    """Close the request-scoped database connection if it exists."""
     conn = g.pop("db_conn", None)
     if conn is not None:
+        # Connections are per-request, so close them on teardown.
         conn.close()
 
 
 # Optional: register teardown in app factory if you prefer
 def init_app(app):
+    """Register teardown handling so the connection closes automatically."""
     app.teardown_appcontext(close_db)

--- a/server/extensions/llm.py
+++ b/server/extensions/llm.py
@@ -8,6 +8,7 @@ _use_llm = None
 
 
 def get_llm():
+    """Instantiate and cache the configured ChatOpenAI client if available."""
     global _llm, _use_llm
     if _use_llm is not None:
         return _llm, _use_llm
@@ -17,6 +18,7 @@ def get_llm():
 
         model = current_app.config.get("MUNRO_CHAT_MODEL", "gpt-4o-mini")
         key = current_app.config.get("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
+        # Lazily construct the client once we have all configuration values.
         _llm = ChatOpenAI(model=model, temperature=0, openai_api_key=key)
         _use_llm = True
     except Exception:

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -8,7 +8,9 @@ from db import init_app as init_db
 
 
 def register_blueprints(app: Flask):
+    """Attach all API blueprints and initialise the shared database hooks."""
     init_db(app)
+    # Each blueprint serves a logical feature area of the API.
     app.register_blueprint(health_bp, url_prefix="/api")
     app.register_blueprint(munros_bp, url_prefix="/api")
     app.register_blueprint(tags_bp, url_prefix="/api")

--- a/server/routes/chat.py
+++ b/server/routes/chat.py
@@ -33,6 +33,7 @@ _LOCATION_PATTERNS = [
 
 
 def extract_location_heuristic(text: str) -> str:
+    """Return a lightweight regex-based guess at the mentioned location."""
     s = (text or "").strip()
     for pat in _LOCATION_PATTERNS:
         m = re.search(pat, s, flags=re.IGNORECASE)
@@ -43,6 +44,7 @@ def extract_location_heuristic(text: str) -> str:
 
 
 def _coerce_float(x):
+    """Safely convert values into floats, ignoring invalid input."""
     try:
         if x is None:
             return None
@@ -53,6 +55,7 @@ def _coerce_float(x):
 
 @bp.post("/chat")
 def chat():
+    """Handle conversational requests by orchestrating LLM intent parsing and search."""
     llm, use_llm = get_llm()
     if not use_llm:
         return jsonify({"error": "LLM not configured"}), 500
@@ -205,6 +208,7 @@ User message: {user_msg}
         )
 
     def to_route_link(r):
+        """Trim the result payload down to link-friendly metadata."""
         return {"id": r["id"], "name": r["name"], "tags": r.get("tags", [])}
 
     route_links = [to_route_link(r) for r in candidates[:limit]]

--- a/server/routes/health.py
+++ b/server/routes/health.py
@@ -5,4 +5,5 @@ bp = Blueprint("health", __name__)
 
 @bp.get("/health")
 def health():
+    """Return a simple health indicator for monitoring probes."""
     return jsonify({"ok": True})

--- a/server/routes/munros.py
+++ b/server/routes/munros.py
@@ -6,17 +6,21 @@ bp = Blueprint("munros", __name__)
 
 @bp.get("/munros")
 def get_munros():
+    """Return a filtered list of Munros based on optional query parameters."""
     grade = request.args.get("grade", type=int)
     bog = request.args.get("bog", type=int)
     search = request.args.get("search", type=str)
     mid = request.args.get("id", type=int)
+    # Delegate the actual filtering to the service layer.
     out = list_munros(grade=grade, bog=bog, search=search, mid=mid)
     return jsonify(out), 200, {"Content-Type": "application/json; charset=utf-8"}
 
 
 @bp.get("/munro/<int:mid>")
 def get_munro(mid: int):
+    """Return detail for a single Munro or a 404 if it cannot be found."""
     d = fetch_one(mid)
     if not d:
         return jsonify({"error": "not found"}), 404
+    # Successful lookups include the fully hydrated record.
     return jsonify(d), 200

--- a/server/routes/search.py
+++ b/server/routes/search.py
@@ -6,6 +6,7 @@ bp = Blueprint("search", __name__)
 
 @bp.post("/search")
 def search_munros():
+    """Dispatch searches via either text/tag filters or location lookups."""
     data = request.get_json(force=True) or {}
     location = (data.get("location") or "").strip()
     limit = int(data.get("limit") or 12)
@@ -13,12 +14,14 @@ def search_munros():
     if location:
         # Location-first path: softer semantics, distance-weighted
         include_tags = data.get("include_tags") or []
+        # Let the service layer handle distance-weighted results.
         resp = search_by_location_core(
             location=location, include_tags=include_tags, limit=limit
         )
         return jsonify(resp)
 
     # Default text/tag search path
+    # Build the payload once so the service can execute the multi-pass strategy.
     resp = search_core(
         {
             "query": (data.get("query") or "").strip(),

--- a/server/routes/tags.py
+++ b/server/routes/tags.py
@@ -6,4 +6,5 @@ bp = Blueprint("tags", __name__)
 
 @bp.get("/tags")
 def list_tags():
+    """List all tags with their associated counts."""
     return jsonify(list_tags_with_counts())

--- a/server/seed.py
+++ b/server/seed.py
@@ -11,6 +11,7 @@ JSON_PATH = "munro_descriptions.json"
 
 # ---------- Helpers ----------
 def fix_mojibake(s: str) -> str:
+    """Repair common mojibake sequences produced by mis-decoded text."""
     if not isinstance(s, str):
         return s
     try:
@@ -23,6 +24,7 @@ def fix_mojibake(s: str) -> str:
 
 
 def to_nfc(s: str) -> str:
+    """Normalise Unicode strings into NFC form."""
     return unicodedata.normalize("NFC", s or "")
 
 
@@ -31,6 +33,7 @@ DASH = {"\u2013": "-", "\u2014": "-", "\u2212": "-"}
 
 
 def clean_text(s: Any) -> Any:
+    """Apply mojibake fixes and replace troublesome punctuation."""
     if not isinstance(s, str):
         return s
     s = fix_mojibake(s)
@@ -43,12 +46,14 @@ def clean_text(s: Any) -> Any:
 
 
 def clean_gpx(path: Any) -> Any:
+    """Normalise GPX file paths to forward slashes."""
     if not isinstance(path, str):
         return path
     return path.replace("\\", "/")
 
 
 def snake(s: str) -> str:
+    """Convert arbitrary strings into safe snake_case column names."""
     # lower, replace non-alnum with _, collapse, trim
     s = re.sub(r"[^0-9A-Za-z]+", "_", s).strip("_").lower()
     s = re.sub(r"_+", "_", s)
@@ -58,12 +63,14 @@ def snake(s: str) -> str:
 
 
 def canonicalize_name(name: str) -> str:
+    """Return a cleaned display name for a Munro."""
     s = clean_text(name)
     s = re.sub(r"\s+", " ", s).strip()
     return s
 
 
 def canonical_key(name: str) -> str:
+    """Create a case-insensitive key suitable for deduplicating names."""
     s = canonicalize_name(name)
     s = s.casefold()
     # unify apostrophes/dashes in key

--- a/server/services/geo_service.py
+++ b/server/services/geo_service.py
@@ -12,6 +12,7 @@ SCOTLAND_BBOX = getattr(munro_coords, "SCOTLAND_BBOX", (54.5, -8.5, 60.9, -0.5))
 
 
 def _within_bbox(lat: float, lon: float, bbox=SCOTLAND_BBOX) -> bool:
+    """Return True when the coordinate falls within the configured bbox."""
     s, w, n, e = bbox
     return (s <= lat <= n) and (w <= lon <= e)
 
@@ -144,6 +145,7 @@ def _select_row(conn, name_like: Optional[str] = None, exact: Optional[str] = No
 
 
 def _map_names_to_db_rows(named: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Join geocoded results with rich DB records while preserving distance."""
     if not named:
         return []
     with get_db() as conn:
@@ -192,6 +194,7 @@ def _map_names_to_db_rows(named: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def attach_tags(rows: List[Dict[str, Any]]) -> None:
+    """Populate a list of row dicts with their associated tag collections."""
     if not rows:
         return
     ids = [r["id"] for r in rows]

--- a/server/services/munro_service.py
+++ b/server/services/munro_service.py
@@ -3,6 +3,7 @@ from db import get_db
 
 
 def list_munros(grade=None, bog=None, search=None, mid=None) -> List[Dict[str, Any]]:
+    """Return Munro rows filtered by the provided criteria."""
     base_sql = "SELECT * FROM munros WHERE 1=1"
     clauses, params = [], []
 
@@ -26,6 +27,7 @@ def list_munros(grade=None, bog=None, search=None, mid=None) -> List[Dict[str, A
         like = f"%{search}%"
         params.extend([like, like, like])
 
+    # Stitch the dynamic WHERE clause together.
     sql = " ".join([base_sql, *clauses])
     with get_db() as conn:
         rows = conn.execute(sql, params).fetchall()
@@ -33,22 +35,26 @@ def list_munros(grade=None, bog=None, search=None, mid=None) -> List[Dict[str, A
     out = []
     for r in rows:
         d = dict(r)
+        # The normalised key is internal-only; omit it from API responses.
         d.pop("normalized_name", None)
         out.append(d)
     return out
 
 
 def get_munro(mid: int) -> Dict[str, Any] | None:
+    """Return a single Munro record by ID if present."""
     with get_db() as conn:
         row = conn.execute("SELECT * FROM munros WHERE id = ?", (mid,)).fetchone()
     if not row:
         return None
     d = dict(row)
+    # Drop internal columns before returning to callers.
     d.pop("normalized_name", None)
     return d
 
 
 def list_tags_with_counts() -> List[Dict[str, Any]]:
+    """Return tag usage counts ordered by frequency then alphabetically."""
     with get_db() as conn:
         rows = conn.execute("""
             SELECT tag, COUNT(*) AS n
@@ -56,4 +62,5 @@ def list_tags_with_counts() -> List[Dict[str, Any]]:
             GROUP BY tag
             ORDER BY n DESC, tag ASC
         """).fetchall()
+    # Convert sqlite rows into plain dicts expected by the API layer.
     return [{"tag": r["tag"], "count": r["n"]} for r in rows]

--- a/server/utils/filters.py
+++ b/server/utils/filters.py
@@ -31,6 +31,7 @@ TIME_PATTERNS = [
 
 
 def _to_km(value: float, unit: str) -> float:
+    """Convert distance values expressed in miles into kilometres."""
     u = unit.lower()
     if u.startswith("km") or "kilomet" in u:
         return value
@@ -39,16 +40,13 @@ def _to_km(value: float, unit: str) -> float:
 
 
 def _to_hours(value: float, unit: str) -> float:
+    """Normalise supported hour tokens to a plain hour count."""
     # all time units above are hours already
     return value
 
 
 def parse_numeric_filters(text: str) -> Dict[str, float]:
-    """
-    Returns a dict possibly containing:
-      - distance_min_km, distance_max_km
-      - time_min_h, time_max_h
-    """
+    """Extract numeric distance and time hints from free-form text."""
     s = (text or "").lower()
     out: Dict[str, float] = {}
 

--- a/server/utils/query.py
+++ b/server/utils/query.py
@@ -51,16 +51,19 @@ DIFF_WORD_TO_NUM = {
 
 
 def tokenize(q: str) -> List[str]:
+    """Split a query string into lowercase tokens, stripping punctuation."""
     return [t for t in re.split(r"[^\w']+", (q or "").lower()) if t]
 
 
 def quote_or_prefix(term: str) -> str:
+    """Return an FTS-safe token, quoting phrases and prefixing long words."""
     if " " in term:
         return f'"{term}"'
     return f"{term[:5]}*" if len(term) >= 5 else term
 
 
 def expand_query_for_fts(q: str) -> str:
+    """Generate an FTS query string including light synonym expansion."""
     toks = tokenize(q)
     candidates: list[str] = []
     for t in toks:
@@ -81,6 +84,7 @@ def expand_query_for_fts(q: str) -> str:
 
 
 def build_like_terms(q: str) -> list[str]:
+    """Return LIKE patterns mirroring the logic used for FTS expansion."""
     toks = tokenize(q)
     expanded: list[str] = []
     for t in toks:
@@ -99,6 +103,7 @@ def build_like_terms(q: str) -> list[str]:
 
 
 def normalize_grade_max(value):
+    """Coerce grade filters to comparable numeric values."""
     if value is None:
         return None
     if isinstance(value, str):
@@ -115,6 +120,7 @@ def normalize_grade_max(value):
 
 
 def norm_text(s: str) -> str:
+    """Normalise human text for equality checks and index keys."""
     if not s:
         return ""
     s = s.replace("’", "'").replace("‘", "'").replace("`", "'")


### PR DESCRIPTION
## Summary
- surface the live Munro Scout deployment link prominently at the top of the README
- add a concise "How to use" walkthrough describing search, filtering, chat, and detail exploration flows

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cc4c9a64048322979793ec2e5923d2