### PR TITLE
Document client UI structure with inline comments

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,18 +1,26 @@
+/* ============================= */
+/* Legacy CRA demo styles (unused) */
+/* ============================= */
+
+/* Container for the demo App component */
 .App {
   text-align: center;
 }
 
+/* React logo animation sizing */
 .App-logo {
   height: 40vmin;
   pointer-events: none;
 }
 
+/* Only spin the logo for users who allow motion */
 @media (prefers-reduced-motion: no-preference) {
   .App-logo {
     animation: App-logo-spin infinite 20s linear;
   }
 }
 
+/* Header area shown in CRA starter template */
 .App-header {
   background-color: #282c34;
   min-height: 100vh;
@@ -24,10 +32,12 @@
   color: white;
 }
 
+/* Link color override */
 .App-link {
   color: #61dafb;
 }
 
+/* Keyframes used by the React logo spin */
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -100,7 +100,9 @@ export default function App() {
 
   return (
     <Box minH="100vh" bgGradient="linear(to-br, gray.50, white)">
-      {/* ===== Modern Sticky Header (no icons) ===== */}
+      {/* =============================== */}
+      {/* 🧭 APP SHELL: STICKY HEADER BAR */}
+      {/* =============================== */}
       <Box
         position="sticky"
         top={0}
@@ -121,6 +123,7 @@ export default function App() {
             boxShadow="lg"
           >
             <Flex align="center" justify="space-between" gap={6} wrap="wrap">
+              {/* Branding block */}
               <HStack spacing={3}>
                 <Heading size="md" color="white">
                   Munro Scout
@@ -130,6 +133,7 @@ export default function App() {
                 </Badge>
               </HStack>
 
+              {/* Tagline — hidden on smaller breakpoints to save space */}
               <Text
                 display={{ base: "none", md: "block" }}
                 fontSize="sm"
@@ -138,7 +142,7 @@ export default function App() {
                 Discover and analyze Scotland’s Munros by distance, time, grade & terrain.
               </Text>
 
-              {/* Primary nav — Chat → Details → Dashboard */}
+              {/* Primary nav — toggles between the three experiences */}
               <ButtonGroup spacing={2}>
                 <Button
                   onClick={() => setActiveTab("chat")}
@@ -174,17 +178,23 @@ export default function App() {
         </Container>
       </Box>
 
+      {/* ================================== */}
+      {/* 📊 MAIN CONTENT: TAB-DRIVEN VIEWS */}
+      {/* ================================== */}
       <Container maxW="6xl" py={10}>
         {activeTab === "dashboard" ? (
           <>
+            {/* ----- Dashboard: summary metrics ----- */}
             <Heading size="md" mb={2}>Overview Statistics</Heading>
             <Divider mb={6} />
             <StatsPanel stats={stats} />
 
+            {/* ----- Dashboard: scatter chart ----- */}
             <Heading size="md" mb={2}>Distance vs Time</Heading>
             <Divider mb={6} />
             <ScatterPlot data={munros} />
 
+            {/* ----- Dashboard: filter controls ----- */}
             <Heading size="md" mb={2}>Filters & Sorting</Heading>
             <Divider mb={4} />
             <Filters
@@ -200,6 +210,7 @@ export default function App() {
               onSortOrder={setSortOrder}
             />
 
+            {/* ----- Dashboard: tabular data ----- */}
             <Heading size="md" mb={2}>Munro List</Heading>
             <Divider mb={4} />
             <MunroTable
@@ -208,27 +219,33 @@ export default function App() {
             />
           </>
         ) : activeTab === "chat" ? (
+          /* ----- Conversational assistant tab ----- */
           <ChatTab
             messages={messages}
             onSend={handleSend}
             onOpenRoute={openRoute}
-            onReset={() => setMessages([])}   // ✅ add this line
+            onReset={() => setMessages([])}   // Resets conversation history
           />
         ) : (
+          /* ----- Detailed, per-munro tab ----- */
           <DetailsTab initialMunro={selectedMunro} />
         )}
 
+        {/* Footer attribution */}
         <Text mt={12} textAlign="center" fontSize="sm" color="gray.400">
           Built with Flask, React & Chakra UI — demo project by Dhruv
         </Text>
 
-        {/* Modal for quick preview */}
+        {/* =========================== */}
+        {/* 🪟 QUICK PREVIEW MODAL DIALOG */}
+        {/* =========================== */}
         <Modal isOpen={isOpen} onClose={onClose} size="lg">
           <ModalOverlay />
           <ModalContent>
             <ModalHeader>{selectedMunro?.title || selectedMunro?.name}</ModalHeader>
             <ModalCloseButton />
             <ModalBody>
+              {/* Summary and key stats laid out in a grid */}
               <Text mb={4} fontSize="sm" whiteSpace="pre-wrap">{selectedMunro?.summary}</Text>
               <SimpleGrid columns={2} spacing={4}>
                 <Flex align="center" gap={3}><Text><strong>Distance:</strong> {selectedMunro?.distance} km</Text></Flex>

--- a/client/src/components/dashboard/Filters.tsx
+++ b/client/src/components/dashboard/Filters.tsx
@@ -21,6 +21,7 @@ export default function Filters({
 }: Props) {
   return (
     <Flex gap={4} wrap="wrap" mb={10}>
+      {/* Free-text search */}
       <Input
         placeholder="Search by description..."
         value={search}
@@ -28,13 +29,17 @@ export default function Filters({
         w="full"
         maxW="250px"
       />
+
+      {/* Difficulty filters */}
       <Select
         placeholder="Filter by grade"
         value={grade}
         onChange={(e) => onGrade(e.target.value)}
         maxW="180px"
       >
-        {[1, 2, 3, 4, 5].map(g => <option key={g} value={g}>{g}</option>)}
+        {[1, 2, 3, 4, 5].map((g) => (
+          <option key={g} value={g}>{g}</option>
+        ))}
       </Select>
       <Select
         placeholder="Max bog"
@@ -42,8 +47,12 @@ export default function Filters({
         onChange={(e) => onBog(e.target.value)}
         maxW="180px"
       >
-        {[1, 2, 3, 4, 5].map(b => <option key={b} value={b}>{b}</option>)}
+        {[1, 2, 3, 4, 5].map((b) => (
+          <option key={b} value={b}>{b}</option>
+        ))}
       </Select>
+
+      {/* Sorting controls */}
       <Select
         placeholder="Sort by"
         value={sortKey}

--- a/client/src/components/dashboard/MunroTable.tsx
+++ b/client/src/components/dashboard/MunroTable.tsx
@@ -19,8 +19,10 @@ export default function MunroTable({
       rounded="2xl"
       overflow="hidden"
     >
+      {/* Scrollable table wrapper */}
       <TableContainer maxH="500px" overflowY="auto">
         <Table size="sm" variant="simple">
+          {/* Sticky header keeps labels visible while scrolling */}
           <Thead position="sticky" top={0} bg="blue.500" color="white" zIndex={1}>
             <Tr>
               <Th color="white">Name</Th>
@@ -38,6 +40,7 @@ export default function MunroTable({
                 cursor="pointer"
                 onClick={() => onRowClick(m)}
               >
+                {/* Core route metrics */}
                 <Td fontWeight="semibold">{m.name}</Td>
                 <Td textAlign="center">{m.distance}</Td>
                 <Td textAlign="center">{m.time}</Td>

--- a/client/src/components/dashboard/ScatterPlot.tsx
+++ b/client/src/components/dashboard/ScatterPlot.tsx
@@ -8,6 +8,7 @@ function CustomTooltip({ active, payload }: any) {
   if (active && payload && payload.length) {
     return (
       <Box bg="white" border="1px solid #ccc" px={3} py={2} rounded="md" shadow="sm">
+        {/* Munro name label */}
         <Text fontWeight="semibold">{payload[0].payload.name}</Text>
       </Box>
     );
@@ -18,9 +19,12 @@ function CustomTooltip({ active, payload }: any) {
 export default function ScatterPlot({ data }: { data: Munro[] }) {
   return (
     <Box h="300px" mb={10}>
+      {/* Responsive wrapper keeps the chart fluid */}
       <ResponsiveContainer>
         <ScatterChart margin={{ top: 10, right: 30, bottom: 10, left: 0 }}>
+          {/* Background gridlines */}
           <CartesianGrid strokeDasharray="3 3" />
+          {/* Horizontal axis — hiking distance */}
           <XAxis
             type="number"
             dataKey="distance"
@@ -28,12 +32,14 @@ export default function ScatterPlot({ data }: { data: Munro[] }) {
             domain={[5, 40]}
             label={{ value: "Distance (km)", position: "insideBottomRight", offset: -5 }}
           />
+          {/* Vertical axis — time to summit */}
           <YAxis
             type="number"
             dataKey="time"
             name="Time (hrs)"
             label={{ value: "Time (hrs)", angle: -90, position: "insideLeft" }}
           />
+          {/* Hover tooltip + scatter series */}
           <ChartTooltip content={<CustomTooltip />} cursor={{ strokeDasharray: "3 3" }} />
           <Scatter name="Munros" data={data} fill="#3182ce" isAnimationActive={false} />
         </ScatterChart>

--- a/client/src/components/dashboard/StatsPanel.tsx
+++ b/client/src/components/dashboard/StatsPanel.tsx
@@ -16,21 +16,25 @@ type Stats = {
 export default function StatsPanel({ stats }: { stats: Stats }) {
   return (
     <SimpleGrid columns={{ base: 2, md: 5 }} spacing={4} mb={10}>
+      {/* --- Total number of peaks tracked --- */}
       <Stat>
         <StatLabel>Total Munros</StatLabel>
         <StatNumber>{stats.total}</StatNumber>
       </Stat>
 
+      {/* --- Average distance of filtered set --- */}
       <Stat>
         <StatLabel>Avg Distance</StatLabel>
         <StatNumber>{stats.avgDistance.toFixed(1)} km</StatNumber>
       </Stat>
 
+      {/* --- Average time estimate --- */}
       <Stat>
         <StatLabel>Avg Time</StatLabel>
         <StatNumber>{stats.avgTime.toFixed(1)} hrs</StatNumber>
       </Stat>
 
+      {/* --- Terrain grade indicator --- */}
       <Stat>
         <StatLabel>Avg Grade</StatLabel>
         <StatNumber>
@@ -38,6 +42,7 @@ export default function StatsPanel({ stats }: { stats: Stats }) {
         </StatNumber>
       </Stat>
 
+      {/* --- Bog factor indicator --- */}
       <Stat>
         <StatLabel>Avg Bog</StatLabel>
         <StatNumber>

--- a/client/src/features/chat/ChatTab.tsx
+++ b/client/src/features/chat/ChatTab.tsx
@@ -120,6 +120,7 @@ export default function ChatTab({ messages, onSend, onOpenRoute, onReset }: Prop
 
   return (
     <Box mt={6}>
+      {/* Section header with title + reset */}
       <Flex align="center" justify="space-between" mb={2}>
         <Heading size="md">Chat Assistant</Heading>
 
@@ -163,6 +164,7 @@ export default function ChatTab({ messages, onSend, onOpenRoute, onReset }: Prop
           <>
             {messages.map((msg, idx) => (
               <Box key={idx} mb={4} textAlign={msg.role === "user" ? "right" : "left"}>
+                {/* Message bubble */}
                 <Text
                   display="inline-block"
                   bg={msg.role === "user" ? "blue.100" : "gray.200"}
@@ -213,6 +215,7 @@ export default function ChatTab({ messages, onSend, onOpenRoute, onReset }: Prop
       </Box>
 
       {/* Input bar */}
+      {/* Composer bar with text input + send */}
       <Flex gap={2} position="sticky" bottom={0} bg="white" pb={1}>
         <Input
           aria-label="Chat input"
@@ -362,6 +365,7 @@ function EmptyState({
 }) {
   return (
     <Box textAlign="center" color="gray.700">
+      {/* Prompt the user when the thread is empty */}
       <Heading size="sm" mb={2}>
         Start a conversation
       </Heading>
@@ -426,46 +430,49 @@ function Inspector({ steps }: { steps: any }) {
   }>;
 
   return (
-    <Accordion allowToggle>
-      <AccordionItem border="none">
-        <AccordionButton _expanded={{ bg: "gray.100" }} px={2} py={1} borderRadius="md" fontSize="sm">
-          <Box as="span" flex="1" textAlign="left">
-            How I searched (intent, SQL & results)
-          </Box>
-          <AccordionIcon />
-        </AccordionButton>
-        <AccordionPanel pb={4}>
-          <Box mb={3}>
-            <Text fontWeight="semibold" mb={1} fontSize="sm">
-              Intent
-            </Text>
-            <Code p={2} w="100%" whiteSpace="pre-wrap" fontSize="xs">
-              {JSON.stringify(intent, null, 2)}
-            </Code>
-          </Box>
+    <>
+      {/* Expandable debug inspector for LLM output */}
+      <Accordion allowToggle>
+        <AccordionItem border="none">
+          <AccordionButton _expanded={{ bg: "gray.100" }} px={2} py={1} borderRadius="md" fontSize="sm">
+            <Box as="span" flex="1" textAlign="left">
+              How I searched (intent, SQL & results)
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel pb={4}>
+            <Box mb={3}>
+              <Text fontWeight="semibold" mb={1} fontSize="sm">
+                Intent
+              </Text>
+              <Code p={2} w="100%" whiteSpace="pre-wrap" fontSize="xs">
+                {JSON.stringify(intent, null, 2)}
+              </Code>
+            </Box>
 
-          <Box mb={3}>
-            <Text fontWeight="semibold" mb={1} fontSize="sm">
-              SQL
-            </Text>
-            <Code p={2} w="100%" whiteSpace="pre-wrap" fontSize="xs">
-              {sql}
-            </Code>
-            <Text mt={1} fontSize="xs" color="gray.600">
-              Params: {JSON.stringify(params)}
-            </Text>
-          </Box>
+            <Box mb={3}>
+              <Text fontWeight="semibold" mb={1} fontSize="sm">
+                SQL
+              </Text>
+              <Code p={2} w="100%" whiteSpace="pre-wrap" fontSize="xs">
+                {sql}
+              </Code>
+              <Text mt={1} fontSize="xs" color="gray.600">
+                Params: {JSON.stringify(params)}
+              </Text>
+            </Box>
 
-          <Box>
-            <Text fontWeight="semibold" mb={2} fontSize="sm">
-              Top results
-            </Text>
-            <Stack spacing={3}>
-              {results.map((r) => (
-                <Box key={r.id} p={3} bg="white" border="1px solid #e2e8f0" rounded="md">
-                  <Text fontWeight="bold" mb={1}>
-                    {r.name}
-                  </Text>
+            <Box>
+              <Text fontWeight="semibold" mb={2} fontSize="sm">
+                Top results
+              </Text>
+              <Stack spacing={3}>
+                {results.map((r) => (
+                  <Box key={r.id} p={3} bg="white" border="1px solid #e2e8f0" rounded="md">
+                    <Text fontWeight="bold" mb={1}>
+                      {r.name}
+                    </Text>
+                    {/* Highlight the tags that matched */}
                     <Flex gap={1} wrap="wrap" mb={2}>
                       {r.tags?.slice(0, 14).map((t) => (
                         <Tag key={t} size="sm">
@@ -473,20 +480,21 @@ function Inspector({ steps }: { steps: any }) {
                         </Tag>
                       ))}
                     </Flex>
-                  <Text fontSize="sm" color="gray.700">
-                    {r.summary || "No summary available."}
+                    <Text fontSize="sm" color="gray.700">
+                      {r.summary || "No summary available."}
+                    </Text>
+                  </Box>
+                ))}
+                {results.length === 0 && (
+                  <Text fontSize="sm" color="gray.600">
+                    No results from the current filters.
                   </Text>
-                </Box>
-              ))}
-              {results.length === 0 && (
-                <Text fontSize="sm" color="gray.600">
-                  No results from the current filters.
-                </Text>
-              )}
-            </Stack>
-          </Box>
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
+                )}
+              </Stack>
+            </Box>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </>
   );
 }

--- a/client/src/features/details/DetailsTab.tsx
+++ b/client/src/features/details/DetailsTab.tsx
@@ -114,7 +114,9 @@ export default function DetailsTab({ initialMunro }: Props) {
     <Box mt={6} position="relative">
       <Heading size="md" mb={4}>Explore a Munro</Heading>
 
-      {/* Search Input */}
+      {/* ============================= */}
+      {/* 🔍 SEARCH INPUT + SUGGESTIONS */}
+      {/* ============================= */}
       <Box mb={4} maxW="520px" position="relative">
         <Input
           placeholder="Start typing a Munro name..."
@@ -176,7 +178,9 @@ export default function DetailsTab({ initialMunro }: Props) {
           boxShadow="lg"
           overflow="hidden"
         >
-          {/* Header */}
+          {/* ================= */}
+          {/* 🏔️ HERO HEADER BAR */}
+          {/* ================= */}
           <Box bg="blue.600" color="white" px={6} py={3}>
             <Heading size="lg" lineHeight="short">
               {selected.title || selected.name}
@@ -188,7 +192,9 @@ export default function DetailsTab({ initialMunro }: Props) {
             )}
           </Box>
 
-          {/* Body */}
+          {/* ============== */}
+          {/* 📋 DETAIL BODY */}
+          {/* ============== */}
           <Box p={5}>
             {/* GPX errors */}
             {gpxError && (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,11 @@
+/* ============================ */
+/* Global baseline + Leaflet UI */
+/* ============================ */
+
+/* Bring in Leaflet defaults so the map renders correctly */
 @import "leaflet/dist/leaflet.css";
 
+/* Default typography reset */
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -9,9 +15,14 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Monospace stack for <code> snippets */
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
 
-#map { width: 100%; height: 60vh; }
+/* Utility id for embedded Leaflet map blocks */
+#map {
+  width: 100%;
+  height: 60vh;
+}

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -7,7 +7,9 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 
 root.render(
   <React.StrictMode>
+    {/* ChakraProvider wires up global design tokens/theme */}
     <ChakraProvider>
+      {/* Single-page application shell */}
       <App />
     </ChakraProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- annotate the main App shell, dashboard tabs, and preview modal to describe each layout section
- add inline commentary to dashboard widgets so the stats, scatter plot, filters, and table markup are easier to follow
- document the chat and details tab structures along with global CSS/reset files to guide future contributors

## Testing
- ❌ `CI=true npm test -- --watchAll=false` *(fails: existing Jest setup cannot parse axios ESM import)*

------
https://chatgpt.com/codex/tasks/task_e_68cd75f959748322b2ca6c6cc44fb759